### PR TITLE
add policy for CIS-1.1 - 4.03 Ensure "Block Project-wide SSH keys" is enabled for VM instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ You can easily set up a new (local) policy library by downloading a [bundle](./d
 Download the full policy library and install the [Forseti bundle](./docs/bundles/forseti-security.md):
 ```
 export BUNDLE=forseti-security
-kpt pkg get https://github.com/forseti-security/policy-library.git ./policy-library
+kpt pkg get https://github.com/GoogleCloudPlatform/policy-library.git ./policy-library
 kpt fn source policy-library/samples/ | \
   kpt fn run --image gcr.io/config-validator/get-policy-bundle:latest -- bundle=$BUNDLE | \
   kpt fn sink policy-library/policies/constraints/
 ```
 
-Once you have initialized a library, you might want to save it to [git](./docs/user_guide.md#https://github.com/forseti-security/policy-library/blob/master/docs/user_guide.md#get-started-with-the-policy-library-repository).
+Once you have initialized a library, you might want to save it to [git](./docs/user_guide.md#https://github.com/GoogleCloudPlatform/policy-library/blob/master/docs/user_guide.md#get-started-with-the-policy-library-repository).
 
 ## Developing a Constraint
 
@@ -59,10 +59,10 @@ Replaced:
 ```
 
 ### Linting Policies
-FCV provides a policy linter.  You can invoke it as:
+Config Validator provides a policy linter.  You can invoke it as:
 
 ```
-go get github.com/forseti-security/config-validator/cmd/policy-tool
+go get github.com/GoogleCloudPlatform/config-validator/cmd/policy-tool
 policy-tool --policies ./policies --policies ./samples --libs ./lib
 ```
 

--- a/bundler/dist/generate_docs.js
+++ b/bundler/dist/generate_docs.js
@@ -194,7 +194,7 @@ This bundle can be installed via kpt:
 
 \`\`\`
 export BUNDLE=${bundle.getName()}
-kpt pkg get https://github.com/forseti-security/policy-library.git ./policy-library
+kpt pkg get https://github.com/GoogleCloudPlatform/policy-library.git ./policy-library
 kpt fn source policy-library/samples/ | \\
   kpt fn run --image gcr.io/config-validator/get-policy-bundle:latest -- bundle=$BUNDLE | \\
   kpt fn sink policy-library/policies/constraints/

--- a/bundler/src/generate_docs.ts
+++ b/bundler/src/generate_docs.ts
@@ -205,7 +205,7 @@ This bundle can be installed via kpt:
 
 \`\`\`
 export BUNDLE=${bundle.getName()}
-kpt pkg get https://github.com/forseti-security/policy-library.git ./policy-library
+kpt pkg get https://github.com/GoogleCloudPlatform/policy-library.git ./policy-library
 kpt fn source policy-library/samples/ | \\
   kpt fn run --image gcr.io/config-validator/get-policy-bundle:latest -- bundle=$BUNDLE | \\
   kpt fn sink policy-library/policies/constraints/

--- a/docs/bundles/cis-v1.0.md
+++ b/docs/bundles/cis-v1.0.md
@@ -4,7 +4,7 @@ This bundle can be installed via kpt:
 
 ```
 export BUNDLE=cis-v1.0
-kpt pkg get https://github.com/forseti-security/policy-library.git ./policy-library
+kpt pkg get https://github.com/GoogleCloudPlatform/policy-library.git ./policy-library
 kpt fn source policy-library/samples/ | \
   kpt fn run --image gcr.io/config-validator/get-policy-bundle:latest -- bundle=$BUNDLE | \
   kpt fn sink policy-library/policies/constraints/

--- a/docs/bundles/cis-v1.1.md
+++ b/docs/bundles/cis-v1.1.md
@@ -4,7 +4,7 @@ This bundle can be installed via kpt:
 
 ```
 export BUNDLE=cis-v1.1
-kpt pkg get https://github.com/forseti-security/policy-library.git ./policy-library
+kpt pkg get https://github.com/GoogleCloudPlatform/policy-library.git ./policy-library
 kpt fn source policy-library/samples/ | \
   kpt fn run --image gcr.io/config-validator/get-policy-bundle:latest -- bundle=$BUNDLE | \
   kpt fn sink policy-library/policies/constraints/

--- a/docs/bundles/forseti-security.md
+++ b/docs/bundles/forseti-security.md
@@ -4,7 +4,7 @@ This bundle can be installed via kpt:
 
 ```
 export BUNDLE=forseti-security
-kpt pkg get https://github.com/forseti-security/policy-library.git ./policy-library
+kpt pkg get https://github.com/GoogleCloudPlatform/policy-library.git ./policy-library
 kpt fn source policy-library/samples/ | \
   kpt fn run --image gcr.io/config-validator/get-policy-bundle:latest -- bundle=$BUNDLE | \
   kpt fn sink policy-library/policies/constraints/

--- a/docs/bundles/gke-hardening-v2019.11.11.md
+++ b/docs/bundles/gke-hardening-v2019.11.11.md
@@ -4,7 +4,7 @@ This bundle can be installed via kpt:
 
 ```
 export BUNDLE=gke-hardening-v2019.11.11
-kpt pkg get https://github.com/forseti-security/policy-library.git ./policy-library
+kpt pkg get https://github.com/GoogleCloudPlatform/policy-library.git ./policy-library
 kpt fn source policy-library/samples/ | \
   kpt fn run --image gcr.io/config-validator/get-policy-bundle:latest -- bundle=$BUNDLE | \
   kpt fn sink policy-library/policies/constraints/

--- a/docs/bundles/healthcare-baseline-v1.md
+++ b/docs/bundles/healthcare-baseline-v1.md
@@ -4,7 +4,7 @@ This bundle can be installed via kpt:
 
 ```
 export BUNDLE=healthcare-baseline-v1
-kpt pkg get https://github.com/forseti-security/policy-library.git ./policy-library
+kpt pkg get https://github.com/GoogleCloudPlatform/policy-library.git ./policy-library
 kpt fn source policy-library/samples/ | \
   kpt fn run --image gcr.io/config-validator/get-policy-bundle:latest -- bundle=$BUNDLE | \
   kpt fn sink policy-library/policies/constraints/

--- a/docs/bundles/scorecard-v1.md
+++ b/docs/bundles/scorecard-v1.md
@@ -4,7 +4,7 @@ This bundle can be installed via kpt:
 
 ```
 export BUNDLE=scorecard-v1
-kpt pkg get https://github.com/forseti-security/policy-library.git ./policy-library
+kpt pkg get https://github.com/GoogleCloudPlatform/policy-library.git ./policy-library
 kpt fn source policy-library/samples/ | \
   kpt fn run --image gcr.io/config-validator/get-policy-bundle:latest -- bundle=$BUNDLE | \
   kpt fn sink policy-library/policies/constraints/

--- a/docs/kpt_functions.md
+++ b/docs/kpt_functions.md
@@ -4,7 +4,7 @@ This repo contains several [KPT](https://googlecontainertools.github.io/kpt-func
 These functions are meant to be run against this repo. Before running one of the below functions run `kpt get`:
 
 ```
-kpt pkg get https://github.com/forseti-security/policy-library.git ./policy-library
+kpt pkg get https://github.com/GoogleCloudPlatform/policy-library.git ./policy-library
 ```
 
 ## Get Policy Bundle

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -12,7 +12,7 @@
   * [Install Terraform Validator](#install-terraform-validator)
   * [For local development environments](#for-local-development-environments)
   * [For Production Environments](#for-production-environments)
-* [How to Use Forseti Config Validator](#how-to-use-forseti-config-validator)
+* [How to Use Config Validator with Forseti](#how-to-use-config-validator-with-Forseti)
   * [Deploy Forseti](#deploy-forseti)
   * [Policy Library Sync from Git Repository](https://forsetisecurity.org/docs/latest/configure/config-validator/policy-library-sync-from-git-repo.html)
   * [Policy Library Sync from GCS](https://forsetisecurity.org/docs/latest/configure/config-validator/policy-library-sync-from-gcs.html)
@@ -54,8 +54,8 @@ details, [check out Terraform Validator](#how-to-use-terraform-validator).
 
 Frequently scan the platform for constraint violations and send notifications
 when a violation is found. The monitoring logic that Config Validator uses will
-be built into a number of monitoring tools. For details,
-[check out Forseti Validator](#how-to-use-forseti-config-validator).
+be built into a number of monitoring tools. For example,
+[check out How to Use Config Validator with Forseti](#how-to-use-config-validator-with-forseti).
 
 The following guide will walk you through initial setup steps and instructions
 on how to use Config Validator. By the end, you will have a proof-of-concept to
@@ -81,9 +81,12 @@ Google provides a sample repository with a set of pre-defined constraint
 templates. You can duplicate this repository into a private repository. First
 you should create a new **private** git repository. For example, if you use
 GitHub then you can use the [GitHub UI](https://github.com/new). Then follow the
-steps below to get everything setup. If you are planning on using the [Policy
-Library Sync feature of Forseti](#policy-library-sync), then you should also add
-a read-only user to the private repository which will be used by Forseti.
+steps below to get everything setup. 
+
+_Note: If you are planning on using the
+[Policy Library Sync feature of Forseti](#policy-library-sync),
+then you should also add a read-only user to the private repository which will
+be used by Forseti._
 
 This policy library can also be made public, but it is not recommended. By
 making your policy library public, it would be allowing others to see what you
@@ -98,7 +101,7 @@ providers offer this feature as well.
 
 ```
 export GIT_REPO_ADDR="git@github.com:${YOUR_GITHUB_USERNAME}/policy-library.git"
-git clone --bare https://github.com/forseti-security/policy-library.git
+git clone --bare https://github.com/GoogleCloudPlatform/policy-library.git
 cd policy-library.git
 git push --mirror ${GIT_REPO_ADDR}
 cd ..
@@ -130,7 +133,7 @@ Periodically you should pull any changes from the public repository, which might
 contain new templates and Rego files.
 
 ```
-git remote add public https://github.com/forseti-security/policy-library.git
+git remote add public https://github.com/GoogleCloudPlatform/policy-library.git
 git pull public master
 git push origin master
 ```
@@ -342,7 +345,7 @@ return a `2` exit code if violations are found or `0` if no violations were
 found. Therefore, you should configure your CI to only proceed to the next step
 (for example, `terraform apply`) or merge if the validator exits successfully.
 
-## How to Use Forseti Config Validator
+## How to Use Config Validator with Forseti
 
 ### Deploy Forseti
 
@@ -373,7 +376,7 @@ In this section, you will apply a constraint that enforces IAM policy member
 domain restriction using [Cloud Shell](https://cloud.google.com/shell/).
 
 First click on this
-[link](https://console.cloud.google.com/cloudshell/open?cloudshell_image=gcr.io/graphite-cloud-shell-images/terraform:latest&cloudshell_git_repo=https://github.com/forseti-security/policy-library.git)
+[link](https://console.cloud.google.com/cloudshell/open?cloudshell_image=gcr.io/graphite-cloud-shell-images/terraform:latest&cloudshell_git_repo=https://github.com/GoogleCloudPlatform/policy-library.git)
 to open a new Cloud Shell session. The Cloud Shell session has Terraform
 pre-installed and the Policy Library repository cloned. Once you have the
 session open, the next step is to copy over the sample IAM domain restriction

--- a/policies/constraints/README.md
+++ b/policies/constraints/README.md
@@ -1,1 +1,1 @@
-This directory should contain the constraint .yaml files used in your environment. You can find sample constraints under https://github.com/forseti-security/policy-library/tree/master/samples.
+This directory should contain the constraint .yaml files used in your environment. You can find sample constraints under https://github.com/GoogleCloudPlatform/policy-library/tree/master/samples.

--- a/policies/templates/gcp_compute_block_ssh_keys_v1.yaml
+++ b/policies/templates/gcp_compute_block_ssh_keys_v1.yaml
@@ -1,0 +1,68 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: templates.gatekeeper.sh/v1alpha1
+kind: ConstraintTemplate
+metadata:
+  name: gcp-compute-block-ssh-keys-v1
+spec:
+  crd:
+    spec:
+      names:
+        kind: GCPComputeBlockSSHKeysConstraintV1
+      validation:
+        openAPIV3Schema:
+          { }
+
+  targets:
+    validation.gcp.forsetisecurity.org:
+      rego: | #INLINE("validator/compute_block_ssh_keys.rego")
+        #
+        # Copyright 2021 Google LLC
+        #
+        # Licensed under the Apache License, Version 2.0 (the "License");
+        # you may not use this file except in compliance with the License.
+        # You may obtain a copy of the License at
+        #
+        #      http://www.apache.org/licenses/LICENSE-2.0
+        #
+        # Unless required by applicable law or agreed to in writing, software
+        # distributed under the License is distributed on an "AS IS" BASIS,
+        # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        # See the License for the specific language governing permissions and
+        # limitations under the License.
+        #
+        package templates.gcp.GCPComputeBlockSSHKeysConstraintV1
+        
+        import data.validator.gcp.lib as lib
+        
+        deny[{
+        	"msg": message,
+        	"details": metadata,
+        }] {
+        	constraint := input.constraint
+        	asset := input.asset
+        	asset.asset_type == "compute.googleapis.com/Instance"
+        	instance := asset.resource.data
+        	metadata_config := lib.get_default(instance, "metadata", {})
+        
+        	# check if key and values are as expected
+        	metadata_config.items[i].key == "block-project-ssh-keys"
+        	metadata_config.items[i].value != "true"
+        
+        	message := sprintf("%v Block project-wide SSH keys is not enabled.", [asset.name])
+        	ancestry_path = lib.get_default(asset, "ancestry_path", "")
+        	metadata := {"ancestry_path": ancestry_path}
+        }
+        #ENDINLINE

--- a/samples/compute_block_ssh_keys.yaml
+++ b/samples/compute_block_ssh_keys.yaml
@@ -1,0 +1,26 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPComputeBlockSSHKeysConstraintV1
+metadata:
+  name: compute_block_ssh_keys
+  annotations:
+    description: CIS-1.1 - 4.03 Ensure "Block Project-wide SSH keys" is enabled for VM instances
+spec:
+  severity: high
+  match:
+    gcp:
+      target: [ "organization/*" ]
+  parameters: { }

--- a/validator/compute_block_ssh_keys.rego
+++ b/validator/compute_block_ssh_keys.rego
@@ -1,0 +1,37 @@
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+package templates.gcp.GCPComputeBlockSSHKeysConstraintV1
+
+import data.validator.gcp.lib as lib
+
+deny[{
+	"msg": message,
+	"details": metadata,
+}] {
+	constraint := input.constraint
+	asset := input.asset
+	asset.asset_type == "compute.googleapis.com/Instance"
+	instance := asset.resource.data
+	metadata_config := lib.get_default(instance, "metadata", {})
+
+	# check if key and values are as expected
+	metadata_config.items[i].key == "block-project-ssh-keys"
+	metadata_config.items[i].value != "true"
+
+	message := sprintf("%v Block project-wide SSH keys is not enabled.", [asset.name])
+	ancestry_path = lib.get_default(asset, "ancestry_path", "")
+	metadata := {"ancestry_path": ancestry_path}
+}

--- a/validator/compute_block_ssh_keys_test.rego
+++ b/validator/compute_block_ssh_keys_test.rego
@@ -1,0 +1,43 @@
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+package templates.gcp.GCPComputeBlockSSHKeysConstraintV1
+
+import data.test.fixtures.compute_block_ssh_keys.assets as fixture_instances
+import data.test.fixtures.compute_block_ssh_keys.constraints as fixture_constraints
+
+# Find all violations on our test cases
+find_violations[violation] {
+	instance := data.instances[_]
+	constraint := data.test_constraints[_]
+	issues := deny with input.asset as instance
+		 with input.constraint as constraint
+
+	total_issues := count(issues)
+	violation := issues[_]
+}
+
+# Confim no violations with no instances
+test_block_ssh_keys_no_instances {
+	found_violations := find_violations with data.instances as []
+	count(found_violations) = 0
+}
+
+test_block_ssh_keys_no_constraints {
+	found_violations := find_violations with data.instances as fixture_instances
+		 with data.constraints as []
+
+	count(found_violations) = 0
+}

--- a/validator/test/fixtures/compute_block_ssh_keys/assets/data.json
+++ b/validator/test/fixtures/compute_block_ssh_keys/assets/data.json
@@ -1,0 +1,123 @@
+{
+  "canIpForward": false,
+  "cpuPlatform": "Intel Haswell",
+  "creationTimestamp": "2021-06-06T05:07:07.189-07:00",
+  "deletionProtection": false,
+  "disks": [
+    {
+      "autoDelete": true,
+      "boot": true,
+      "deviceName": "persistent-disk-0",
+      "diskSizeGb": "20",
+      "guestOsFeatures": [
+        {
+          "type": "UEFI_COMPATIBLE"
+        },
+        {
+          "type": "VIRTIO_SCSI_MULTIQUEUE"
+        },
+        {
+          "type": "SEV_CAPABLE"
+        }
+      ],
+      "index": 0,
+      "interface": "SCSI",
+      "kind": "compute#attachedDisk",
+      "licenses": [
+        "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/licenses/centos-8"
+      ],
+      "mode": "READ_WRITE",
+      "source": "https://www.googleapis.com/compute/v1/projects/prj-dev-palani-ram/zones/us-central1-f/disks/pals-jumphost",
+      "type": "PERSISTENT"
+    }
+  ],
+  "fingerprint": "3yO3zonqEK8=",
+  "id": "1384066644687520901",
+  "kind": "compute#instance",
+  "labelFingerprint": "42WmSpB8rSM=",
+  "lastStartTimestamp": "2021-06-09T03:24:12.046-07:00",
+  "lastStopTimestamp": "2021-06-08T22:16:36.143-07:00",
+  "machineType": "https://www.googleapis.com/compute/v1/projects/prj-dev-palani-ram/zones/us-central1-f/machineTypes/e2-micro",
+  "metadata": {
+    "fingerprint": "5_5FO_6FrgA=",
+    "items": [
+      {
+        "key": "block-project-ssh-keys",
+        "value": "true"
+      },
+      {
+        "key": "enable-oslogin",
+        "value": "false"
+      },
+      {
+        "key": "environment",
+        "value": "dev"
+      },
+      {
+        "key": "name",
+        "value": "pals-jumphost"
+      },
+      {
+        "key": "serial-port-enable",
+        "value": "false"
+      },
+      {
+        "key": "startup-script",
+        "value": "echo instance created through terraform > /readme.txt"
+      }
+    ],
+    "kind": "compute#metadata"
+  },
+  "name": "pals-jumphost",
+  "networkInterfaces": [
+    {
+      "accessConfigs": [
+        {
+          "kind": "compute#accessConfig",
+          "name": "external-nat",
+          "natIP": "34.134.200.232",
+          "networkTier": "PREMIUM",
+          "type": "ONE_TO_ONE_NAT"
+        }
+      ],
+      "fingerprint": "ixgiHAEBXKQ=",
+      "kind": "compute#networkInterface",
+      "name": "nic0",
+      "network": "https://www.googleapis.com/compute/v1/projects/prj-dev-palani-ram/global/networks/primary-vpc",
+      "networkIP": "10.10.10.49",
+      "subnetwork": "https://www.googleapis.com/compute/v1/projects/prj-dev-palani-ram/regions/us-central1/subnetworks/primary-dmz-subnet"
+    }
+  ],
+  "scheduling": {
+    "automaticRestart": true,
+    "onHostMaintenance": "MIGRATE",
+    "preemptible": false
+  },
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/prj-dev-palani-ram/zones/us-central1-f/instances/pals-jumphost",
+  "serviceAccounts": [
+    {
+      "email": "srv-acct-admin@prj-dev-palani-ram.iam.gserviceaccount.com",
+      "scopes": [
+        "https://www.googleapis.com/auth/cloud-platform"
+      ]
+    }
+  ],
+  "shieldedInstanceConfig": {
+    "enableIntegrityMonitoring": true,
+    "enableSecureBoot": false,
+    "enableVtpm": true
+  },
+  "shieldedInstanceIntegrityPolicy": {
+    "updateAutoLearnPolicy": true
+  },
+  "startRestricted": false,
+  "status": "RUNNING",
+  "tags": {
+    "fingerprint": "vC5BGPmEymc=",
+    "items": [
+      "egress-inet",
+      "ingress-inet"
+    ]
+  },
+  "zone": "https://www.googleapis.com/compute/v1/projects/prj-dev-palani-ram/zones/us-central1-f"
+}

--- a/validator/test/fixtures/compute_block_ssh_keys/constraints/block_ssh_keys_default/data.yaml
+++ b/validator/test/fixtures/compute_block_ssh_keys/constraints/block_ssh_keys_default/data.yaml
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPComputeBlockSSHKeysConstraintV1
+metadata:
+  name: compute-block-ssh-keys-v1
+  annotations:
+    description: Ensure "Block Project-wide SSH keys" is enabled for VM instances
+spec:
+  severity: high
+  parameters: { }


### PR DESCRIPTION
add policy for CIS-1.1 - 4.03 Ensure "Block Project-wide SSH keys" is enabled for VM instances