### PR TITLE
Add gke_enable_binauthz policy to master

### DIFF
--- a/policies/templates/gcp_gke_enable_binauthz_v1.yaml
+++ b/policies/templates/gcp_gke_enable_binauthz_v1.yaml
@@ -62,7 +62,7 @@ spec:
             	bin_authz := lib.get_default(cluster, "binaryAuthorization", {})
             	bin_authz_enabled := lib.get_default(bin_authz, "enabled", false)
             	bin_authz_enabled == false
-
+            
             	message := sprintf("Binary authorization is not enabled in cluster %v.", [asset.name])
             	metadata := {"resource": asset.name}
             }

--- a/policies/templates/gcp_gke_enable_binauthz_v1.yaml
+++ b/policies/templates/gcp_gke_enable_binauthz_v1.yaml
@@ -1,0 +1,69 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Check to see if GKE stackdriver monitoring is enabled
+# https://cloud.google.com/monitoring/kubernetes-engine/
+
+apiVersion: templates.gatekeeper.sh/v1alpha1
+kind: ConstraintTemplate
+metadata:
+  name: gcp-gke-enable-binary-authorization-v1
+spec:
+  crd:
+    spec:
+      names:
+        kind: GCPGKEEnableBinAuthzConstraintV1
+      validation:
+        openAPIV3Schema:
+          properties: {}
+  targets:
+    validation.gcp.forsetisecurity.org:
+      rego: | #INLINE("validator/gke_enable_binauthz.rego")
+            #
+            # Copyright 2019 Google LLC
+            #
+            # Licensed under the Apache License, Version 2.0 (the "License");
+            # you may not use this file except in compliance with the License.
+            # You may obtain a copy of the License at
+            #
+            #      http://www.apache.org/licenses/LICENSE-2.0
+            #
+            # Unless required by applicable law or agreed to in writing, software
+            # distributed under the License is distributed on an "AS IS" BASIS,
+            # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+            # See the License for the specific language governing permissions and
+            # limitations under the License.
+            #
+            
+            package templates.gcp.GCPGKEEnableBinAuthzConstraintV1
+            
+            import data.validator.gcp.lib as lib
+            
+            deny[{
+            	"msg": message,
+            	"details": metadata,
+            }] {
+            	constraint := input.constraint
+            	asset := input.asset
+            	asset.asset_type == "container.googleapis.com/Cluster"
+            
+            	cluster := asset.resource.data
+            	bin_authz := lib.get_default(cluster, "binaryAuthorization", {})
+            	bin_authz_enabled := lib.get_default(bin_authz, "enabled", false)
+            	bin_authz_enabled == false
+
+            	message := sprintf("Binary authorization is not enabled in cluster %v.", [asset.name])
+            	metadata := {"resource": asset.name}
+            }
+            #ENDINLINE

--- a/samples/gke_enable_binauthz.yaml
+++ b/samples/gke_enable_binauthz.yaml
@@ -1,0 +1,24 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPGKEEnableBinAuthzConstraintV1
+metadata:
+  name: gke-enable-binary-authorization
+spec:
+  severity: high
+  match:
+    gcp:
+      target: ["organization/*"]
+  parameters: {}

--- a/validator/gke_enable_binauthz.rego
+++ b/validator/gke_enable_binauthz.rego
@@ -30,8 +30,7 @@ deny[{
 	bin_authz := lib.get_default(cluster, "binaryAuthorization", {})
 	bin_authz_enabled := lib.get_default(bin_authz, "enabled", false)
 	bin_authz_enabled == false
-	ancestry_path = lib.get_default(asset, "ancestry_path", "")
 
 	message := sprintf("Binary authorization is not enabled in cluster %v.", [asset.name])
-	metadata := {"resource": asset.name, "ancestry_path": ancestry_path}
+	metadata := {"resource": asset.name}
 }

--- a/validator/gke_enable_binauthz.rego
+++ b/validator/gke_enable_binauthz.rego
@@ -1,0 +1,37 @@
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package templates.gcp.GCPGKEEnableBinAuthzConstraintV1
+
+import data.validator.gcp.lib as lib
+
+deny[{
+	"msg": message,
+	"details": metadata,
+}] {
+	constraint := input.constraint
+	asset := input.asset
+	asset.asset_type == "container.googleapis.com/Cluster"
+
+	cluster := asset.resource.data
+	bin_authz := lib.get_default(cluster, "binaryAuthorization", {})
+	bin_authz_enabled := lib.get_default(bin_authz, "enabled", false)
+	bin_authz_enabled == false
+	ancestry_path = lib.get_default(asset, "ancestry_path", "")
+
+	message := sprintf("Binary authorization is not enabled in cluster %v.", [asset.name])
+	metadata := {"resource": asset.name, "ancestry_path": ancestry_path}
+}

--- a/validator/gke_enable_binauthz_test.rego
+++ b/validator/gke_enable_binauthz_test.rego
@@ -1,0 +1,40 @@
+#
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package templates.gcp.GCPGKEEnableBinAuthzConstraintV1
+
+import data.validator.gcp.lib as lib
+
+all_violations[violation] {
+	resource := data.test.fixtures.gke_enable_binauthz.assets[_]
+	constraint := data.test.fixtures.gke_enable_binauthz.constraints.gke_enable_binauthz
+
+	issues := deny with input.asset as resource
+		 with input.constraint as constraint
+
+	violation := issues[_]
+}
+
+test_binauthz_enabled {
+	violation := all_violations[_]
+	resource_names := {x | x = all_violations[_].details.resource}
+	not resource_names["//container.googleapis.com/projects/transfer-repos/zones/us-central1-c/clusters/joe-clust2"]
+}
+
+test_binauthz_disabled {
+	violation := all_violations[_]
+	violation.details.resource == "//container.googleapis.com/projects/transfer-repos/zones/us-central1-c/clusters/joe-clust"
+}

--- a/validator/test/fixtures/gke_enable_binauthz/assets/data.json
+++ b/validator/test/fixtures/gke_enable_binauthz/assets/data.json
@@ -1,0 +1,161 @@
+[
+{
+    "name": "//container.googleapis.com/projects/transfer-repos/zones/us-central1-c/clusters/joe-clust",
+    "asset_type": "container.googleapis.com/Cluster",
+    "resource": {
+      "version": "v1",
+      "discovery_document_uri": "https://container.googleapis.com/$discovery/rest",
+      "discovery_name": "Cluster",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/282148707733",
+      "data": {
+        "addonsConfig": {
+          "networkPolicyConfig": {
+            "disabled": true
+          }
+        },
+        "clusterIpv4Cidr": "10.44.0.0/14",
+        "createTime": "2016-11-19T05:58:02+00:00",
+        "currentMasterVersion": "1.10.11-gke.1",
+        "currentNodeCount": 4,
+        "currentNodeVersion": "1.4.6",
+        "endpoint": "104.196.229.72",
+        "initialClusterVersion": "1.4.6",
+        "instanceGroupUrls": [
+          "https://www.googleapis.com/compute/v1/projects/pso-cicd8/zones/us-west1-b/instanceGroupManagers/gke-canary-west-default-pool-496ebc1d-grp"
+        ],
+        "legacyAbac": {
+          "enabled": true
+        },
+        "location": "us-west1-b",
+        "locations": [
+          "us-west1-b"
+        ],
+        "loggingService": "logging.googleapis.com",
+        "monitoringService": "monitoring.googleapis.com",
+        "name": "canary-west",
+        "network": "default",
+        "networkConfig": {
+          "network": "projects/pso-cicd8/global/networks/default",
+          "subnetwork": "projects/pso-cicd8/regions/us-west1/subnetworks/default"
+        },
+        "nodeIpv4CidrSize": 24,
+        "nodePools": [
+          {
+            "autoscaling": {},
+            "config": {
+              "diskSizeGb": 100,
+              "imageType": "COS",
+              "machineType": "n1-standard-1",
+              "oauthScopes": [
+                "https://www.googleapis.com/auth/compute",
+                "https://www.googleapis.com/auth/devstorage.read_only",
+                "https://www.googleapis.com/auth/logging.write",
+                "https://www.googleapis.com/auth/servicecontrol",
+                "https://www.googleapis.com/auth/service.management.readonly",
+                "https://www.googleapis.com/auth/trace.append"
+              ],
+              "serviceAccount": "default"
+            },
+            "initialNodeCount": 2,
+            "instanceGroupUrls": [
+              "https://www.googleapis.com/compute/v1/projects/pso-cicd8/zones/us-west1-b/instanceGroupManagers/gke-canary-west-default-pool-496ebc1d-grp"
+            ],
+            "management": {
+              "autoUpgrade": "true"
+            },
+            "name": "default-pool",
+            "selfLink": "https://container.googleapis.com/v1/projects/pso-cicd8/zones/us-west1-b/clusters/canary-west/nodePools/default-pool",
+            "status": "RUNNING",
+            "version": "1.4.6"
+          }
+        ],
+        "selfLink": "https://container.googleapis.com/v1/projects/pso-cicd8/zones/us-west1-b/clusters/canary-west",
+        "servicesIpv4Cidr": "10.47.240.0/20",
+        "status": "RUNNING",
+        "subnetwork": "default",
+        "zone": "us-west1-b"
+      }
+    }
+  },
+  {
+    "name": "//container.googleapis.com/projects/transfer-repos/zones/us-central1-c/clusters/joe-clust2",
+    "asset_type": "container.googleapis.com/Cluster",
+    "resource": {
+      "version": "v1",
+      "discovery_document_uri": "https://container.googleapis.com/$discovery/rest",
+      "discovery_name": "Cluster",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/282148707733",
+      "data": {
+        "addonsConfig": {
+          "networkPolicyConfig": {
+            "disabled": true
+          }
+        },
+        "binaryAuthorization": {
+          "enabled": true
+        },
+        "clusterIpv4Cidr": "10.44.0.0/14",
+        "createTime": "2016-11-19T05:58:02+00:00",
+        "currentMasterVersion": "1.10.11-gke.1",
+        "currentNodeCount": 4,
+        "currentNodeVersion": "1.4.6",
+        "endpoint": "104.196.229.72",
+        "initialClusterVersion": "1.4.6",
+        "instanceGroupUrls": [
+          "https://www.googleapis.com/compute/v1/projects/pso-cicd8/zones/us-west1-b/instanceGroupManagers/gke-canary-west-default-pool-496ebc1d-grp"
+        ],
+        "legacyAbac": {
+          "enabled": true
+        },
+        "location": "us-west1-b",
+        "locations": [
+          "us-west1-b"
+        ],
+        "loggingService": "logging.googleapis.com",
+        "monitoringService": "none",
+        "name": "canary-west",
+        "network": "default",
+        "networkConfig": {
+          "network": "projects/pso-cicd8/global/networks/default",
+          "subnetwork": "projects/pso-cicd8/regions/us-west1/subnetworks/default"
+        },
+        "nodeIpv4CidrSize": 24,
+        "nodePools": [
+          {
+            "autoscaling": {},
+            "config": {
+              "diskSizeGb": 100,
+              "imageType": "COS",
+              "machineType": "n1-standard-1",
+              "oauthScopes": [
+                "https://www.googleapis.com/auth/compute",
+                "https://www.googleapis.com/auth/devstorage.read_only",
+                "https://www.googleapis.com/auth/logging.write",
+                "https://www.googleapis.com/auth/servicecontrol",
+                "https://www.googleapis.com/auth/service.management.readonly",
+                "https://www.googleapis.com/auth/trace.append"
+              ],
+              "serviceAccount": "default"
+            },
+            "initialNodeCount": 2,
+            "instanceGroupUrls": [
+              "https://www.googleapis.com/compute/v1/projects/pso-cicd8/zones/us-west1-b/instanceGroupManagers/gke-canary-west-default-pool-496ebc1d-grp"
+            ],
+            "management": {
+              "autoUpgrade": "true"
+            },
+            "name": "default-pool",
+            "selfLink": "https://container.googleapis.com/v1/projects/pso-cicd8/zones/us-west1-b/clusters/canary-west/nodePools/default-pool",
+            "status": "RUNNING",
+            "version": "1.4.6"
+          }
+        ],
+        "selfLink": "https://container.googleapis.com/v1/projects/pso-cicd8/zones/us-west1-b/clusters/canary-west",
+        "servicesIpv4Cidr": "10.47.240.0/20",
+        "status": "RUNNING",
+        "subnetwork": "default",
+        "zone": "us-west1-b"
+      }
+    }
+  }
+]

--- a/validator/test/fixtures/gke_enable_binauthz/constraints/gke_enable_binauthz/data.yaml
+++ b/validator/test/fixtures/gke_enable_binauthz/constraints/gke_enable_binauthz/data.yaml
@@ -1,0 +1,24 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPGKEEnableBinAuthzConstraintV1
+metadata:
+  name: enable_gke_binary_authorization
+spec:
+  severity: high
+  match:
+    gcp:
+      target: ["organization/*"]
+  parameters: {}


### PR DESCRIPTION
Fixes #419 

- Copied `gcp_gke_enable_binauthz_v1` template without `ancestry_path`
- Copied sample `gke_enable_binauthz` constraint
- Copied source Rego without `ancestry_path` and test Rego
- Copied fixture test data and test constraint