### PR TITLE
fix:adds the doc-gen fix to the JS file in dist/

### DIFF
--- a/bundler/dist/generate_docs.js
+++ b/bundler/dist/generate_docs.js
@@ -196,7 +196,7 @@ This bundle can be installed via kpt:
 export BUNDLE=${bundle.getName()}
 kpt pkg get https://github.com/GoogleCloudPlatform/policy-library.git ./policy-library
 kpt fn source policy-library/samples/ | \\
-  kpt fn run --image gcr.io/config-validator/get-policy-bundle:latest -- bundle=$BUNDLE | \\
+  kpt fn eval - --image gcr.io/config-validator/get-policy-bundle:latest -- bundle=$BUNDLE | \\
   kpt fn sink policy-library/policies/constraints/
 \`\`\`
 


### PR DESCRIPTION
This was missed in the last commit and most likely the reason why the build is failing.