### PR TITLE
fix: update constraint for vpc flow logs to check on new field

### DIFF
--- a/policies/templates/gcp_network_enable_flow_logs_v1.yaml
+++ b/policies/templates/gcp_network_enable_flow_logs_v1.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Ensure flow logs are enabled
+# Ensure flow logs are enabled 
 # https://cloud.google.com/vpc/docs/using-flow-logs
 
 apiVersion: templates.gatekeeper.sh/v1alpha1
@@ -45,11 +45,11 @@ spec:
             # See the License for the specific language governing permissions and
             # limitations under the License.
             #
-
+            
             package templates.gcp.GCPNetworkEnableFlowLogsConstraintV1
-
+            
             import data.validator.gcp.lib as lib
-
+            
             deny[{
             	"msg": message,
             	"details": metadata,
@@ -57,15 +57,15 @@ spec:
             	constraint := input.constraint
             	asset := input.asset
             	asset.asset_type == "compute.googleapis.com/Subnetwork"
-
+            
             	network := asset.resource.data
             	legacy_enable_flow_logs := lib.get_default(network, "enableFlowLogs", false)
             	log_config := lib.get_default(network, "logConfig", {})
             	log_config_enable_flow_logs := lib.get_default(log_config, "enable", false)
-
+            
             	log_config_enable_flow_logs != true
             	legacy_enable_flow_logs != true
-
+            
             	message := sprintf("Flow logs are disabled in subnetwork %v.", [asset.name])
             	metadata := {"resource": asset.name}
             }

--- a/policies/templates/gcp_network_enable_flow_logs_v1.yaml
+++ b/policies/templates/gcp_network_enable_flow_logs_v1.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Ensure flow logs are enabled 
+# Ensure flow logs are enabled
 # https://cloud.google.com/vpc/docs/using-flow-logs
 
 apiVersion: templates.gatekeeper.sh/v1alpha1
@@ -45,11 +45,11 @@ spec:
             # See the License for the specific language governing permissions and
             # limitations under the License.
             #
-            
+
             package templates.gcp.GCPNetworkEnableFlowLogsConstraintV1
-            
+
             import data.validator.gcp.lib as lib
-            
+
             deny[{
             	"msg": message,
             	"details": metadata,
@@ -57,14 +57,14 @@ spec:
             	constraint := input.constraint
             	asset := input.asset
             	asset.asset_type == "compute.googleapis.com/Subnetwork"
-            
-            	network := asset.resource.data
-              legacy_enable_flow_logs := lib.get_default(network, "enableFlowLogs", false)
-              log_config := lib.get_default(network, "logConfig", {})
-              log_config_enable_flow_logs := lib.get_default(log_config, "enable", false)
 
-              log_config_enable_flow_logs != true
-              legacy_enable_flow_logs != true
+            	network := asset.resource.data
+            	legacy_enable_flow_logs := lib.get_default(network, "enableFlowLogs", false)
+            	log_config := lib.get_default(network, "logConfig", {})
+            	log_config_enable_flow_logs := lib.get_default(log_config, "enable", false)
+
+            	log_config_enable_flow_logs != true
+            	legacy_enable_flow_logs != true
 
             	message := sprintf("Flow logs are disabled in subnetwork %v.", [asset.name])
             	metadata := {"resource": asset.name}

--- a/policies/templates/gcp_network_enable_flow_logs_v1.yaml
+++ b/policies/templates/gcp_network_enable_flow_logs_v1.yaml
@@ -59,9 +59,13 @@ spec:
             	asset.asset_type == "compute.googleapis.com/Subnetwork"
             
             	network := asset.resource.data
-            	enable_flow_logs := lib.get_default(network, "enableFlowLogs", false)
-            	enable_flow_logs == false
-            
+              legacy_enable_flow_logs := lib.get_default(network, "enableFlowLogs", false)
+              log_config := lib.get_default(network, "logConfig", {})
+              log_config_enable_flow_logs := lib.get_default(log_config, "enable", false)
+
+              log_config_enable_flow_logs != true
+              legacy_enable_flow_logs != true
+
             	message := sprintf("Flow logs are disabled in subnetwork %v.", [asset.name])
             	metadata := {"resource": asset.name}
             }

--- a/validator/network_enable_flow_logs.rego
+++ b/validator/network_enable_flow_logs.rego
@@ -27,8 +27,12 @@ deny[{
 	asset.asset_type == "compute.googleapis.com/Subnetwork"
 
 	network := asset.resource.data
-	enable_flow_logs := lib.get_default(network, "enableFlowLogs", false)
-	enable_flow_logs == false
+	legacy_enable_flow_logs := lib.get_default(network, "enableFlowLogs", false)
+	log_config := lib.get_default(network, "logConfig", {})
+	log_config_enable_flow_logs := lib.get_default(log_config, "enable", false)
+
+	log_config_enable_flow_logs != true
+	legacy_enable_flow_logs != true
 
 	message := sprintf("Flow logs are disabled in subnetwork %v.", [asset.name])
 	metadata := {"resource": asset.name}

--- a/validator/test/fixtures/network_enable_flow_logs/assets/data.json
+++ b/validator/test/fixtures/network_enable_flow_logs/assets/data.json
@@ -44,5 +44,82 @@
         "selfLink": "https://www.googleapis.com/compute/v1/projects/pso-cicd8/regions/us-west1-b/subnetworks/default"
       }
     }
+  },
+  {
+    "name": "//compute.googleapis.com/projects/pso-cicd8/regions/us-west1/subnetworks/both_false",
+    "asset_type": "compute.googleapis.com/Subnetwork",
+    "resource": {
+      "version": "v1",
+      "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/compute/v1/rest",
+      "discovery_name": "Subnetwork",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/13428609260",
+      "data": {
+        "creationTimestamp": "2019-03-13T12:20:27.884-07:00",
+        "fingerprint": "gHOs7GmZw+Q=",
+        "gatewayAddress": "10.140.0.1",
+        "id": "7589039100605557012",
+        "ipCidrRange": "10.140.0.0/20",
+        "name": "default",
+        "network": "https://www.googleapis.com/compute/v1/projects/pso-cicd8/global/networks/default",
+        "privateIpGoogleAccess": true,
+        "enableFlowLogs": false,
+        "logConfig": {
+          "enable": false
+        },
+        "region": "https://www.googleapis.com/compute/v1/projects/pso-cicd8/regions/us-west1-b",
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/pso-cicd8/regions/us-west1-b/subnetworks/default"
+      }
+    }
+  },
+  {
+    "name": "//compute.googleapis.com/projects/pso-cicd8/regions/us-west1/subnetworks/both_correct",
+    "asset_type": "compute.googleapis.com/Subnetwork",
+    "resource": {
+      "version": "v1",
+      "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/compute/v1/rest",
+      "discovery_name": "Subnetwork",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/13428609260",
+      "data": {
+        "creationTimestamp": "2019-03-13T12:20:27.884-07:00",
+        "fingerprint": "gHOs7GmZw+Q=",
+        "gatewayAddress": "10.140.0.1",
+        "id": "7589039100605557012",
+        "ipCidrRange": "10.140.0.0/20",
+        "name": "default",
+        "network": "https://www.googleapis.com/compute/v1/projects/pso-cicd8/global/networks/default",
+        "privateIpGoogleAccess": true,
+        "enableFlowLogs": true,
+        "logConfig": {
+          "enable": true
+        },
+        "region": "https://www.googleapis.com/compute/v1/projects/pso-cicd8/regions/us-west1-b",
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/pso-cicd8/regions/us-west1-b/subnetworks/default"
+      }
+    }
+  },
+  {
+    "name": "//compute.googleapis.com/projects/pso-cicd8/regions/us-west1/subnetworks/only_log_config",
+    "asset_type": "compute.googleapis.com/Subnetwork",
+    "resource": {
+      "version": "v1",
+      "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/compute/v1/rest",
+      "discovery_name": "Subnetwork",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/13428609260",
+      "data": {
+        "creationTimestamp": "2019-03-13T12:20:27.884-07:00",
+        "fingerprint": "gHOs7GmZw+Q=",
+        "gatewayAddress": "10.140.0.1",
+        "id": "7589039100605557012",
+        "ipCidrRange": "10.140.0.0/20",
+        "name": "default",
+        "network": "https://www.googleapis.com/compute/v1/projects/pso-cicd8/global/networks/default",
+        "privateIpGoogleAccess": true,
+        "logConfig": {
+          "enable": true
+        },
+        "region": "https://www.googleapis.com/compute/v1/projects/pso-cicd8/regions/us-west1-b",
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/pso-cicd8/regions/us-west1-b/subnetworks/default"
+      }
+    }
   }
 ]


### PR DESCRIPTION
FIxes #414 

This PR main idea is to consider both versions (old and new) of Flow Logs parameters on the Subnetwork definition:
- Old version - before google provider 3.0: enable_flow_logs
- New version - after google provider 3.0: log_config


If both of them are false, the validation fails.
Some test data were added and tested on it's data test file validator/test/fixtures/network_enable_flow_logs/assets/data.json


**Manual tests:**
We tried to test it manually with a subnetwork resource definition using both versions of google provider (one where it uses the old field and one that uses the new field) but we faced a problem with the old version. 

When we used the validation with `gcloud beta terraform vet` and also `terraform validator` , apparently during the process to convert the Plan json file to CAI, it is always converting to the new model which have the logConfig instead. Even with the old versions with terraform-validator the it keeps converting to a CAI with logConfig. 

So we weren't able to test it manually with the old parameter after all.