### PR TITLE
YAML Syntax Fix for compute_block_ssh_keys policy

### DIFF
--- a/samples/compute_block_ssh_keys.yaml
+++ b/samples/compute_block_ssh_keys.yaml
@@ -22,5 +22,6 @@ metadata:
 spec:
   severity: high
   match:
-    ancestries: ["organization/*"]
+    ancestries: 
+      - "organizations/**"
   parameters: {}


### PR DESCRIPTION
The old syntax is failing validator with MAP errors, YAML syntax was updated to fix the gcloud error. The fix was tested and working as intended.

For Reference, Error with previous Code
```
Validating resources...done.                                                                                                                              
ERROR: gcloud crashed (KeyError): 'map'

If you would like to report this issue, please run the following command:
  gcloud feedback

To check gcloud for common problems, please run the following command:
  gcloud info --run-diagnostics
```